### PR TITLE
Adds the ability to define the value returned when an error occurs but isn’t raised

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,17 @@ configurable options. Here they are with their defaults:
 
 ```ruby
 Pipe::Config.new(
-  :error_handlers => [],   # an array of procs to be called when an error occurs
-  :raise_on_error => true, # tells Pipe to re-raise errors which occur
-  :skip_on => false,       # a truthy value or proc which tells pipe to skip the
-                           # next method in the `through` array
-  :stop_on => false        # a truthy value or proc which tells pipe to stop
-                           # processing and return the current value
+  :error_handlers => [],        # an array of procs to be called when an error
+                                # occurs
+  :raise_on_error => true,      # tells Pipe to re-raise errors which occur
+  :return_on_error => :subject, # when an error happens and raise error is false
+                                # returns the current value of subject defaultly;
+                                # if callable, will return the result of the call
+                                # if not callable, will return the value
+  :skip_on => false,            # a truthy value or proc which tells pipe to skip
+                                # the next method in the `through` array
+  :stop_on => false             # a truthy value or proc which tells pipe to stop
+                                # processing and return the current value
 )
 ```
 

--- a/lib/pipe/config.rb
+++ b/lib/pipe/config.rb
@@ -1,16 +1,18 @@
 module Pipe
   class Config
     attr_accessor :raise_on_error
-    attr_reader :error_handlers, :skip_on, :stop_on
+    attr_reader :error_handlers, :return_on_error, :skip_on, :stop_on
 
     def initialize(
       error_handlers: [],
       raise_on_error: true,
+      return_on_error: :subject,
       skip_on: false,
       stop_on: false
     )
       @error_handlers = error_handlers
       @raise_on_error = raise_on_error
+      @return_on_error = return_on_error
       self.skip_on = skip_on
       self.stop_on = stop_on
     end

--- a/lib/pipe/reducer.rb
+++ b/lib/pipe/reducer.rb
@@ -15,7 +15,7 @@ module Pipe
           process(subj, method)
         rescue => e
           handle_error(:error => e, :method => method, :subject => subj)
-          break subj
+          break error_response(:subject => subj)
         end
       }
     end
@@ -23,6 +23,16 @@ module Pipe
     private
 
     attr_accessor :config, :context, :subject, :through
+
+    def error_response(subject:)
+      if config.return_on_error == :subject
+        subject
+      elsif config.return_on_error.respond_to?(:call)
+        config.return_on_error.call(subject)
+      else
+        config.return_on_error
+      end
+    end
 
     def handle_error(error:, method:, subject:)
       process_error_handlers(

--- a/lib/pipe/reducer.rb
+++ b/lib/pipe/reducer.rb
@@ -14,8 +14,9 @@ module Pipe
 
           process(subj, method)
         rescue => e
-          handle_error(:error => e, :method => method, :subject => subj)
-          break error_response(:subject => subj)
+          payload = {:error => e, :method => method, :subject => subj}
+          handle_error(payload)
+          break error_response(payload)
         end
       }
     end
@@ -24,11 +25,11 @@ module Pipe
 
     attr_accessor :config, :context, :subject, :through
 
-    def error_response(subject:)
+    def error_response(error:, method:, subject:)
       if config.return_on_error == :subject
         subject
       elsif config.return_on_error.respond_to?(:call)
-        config.return_on_error.call(subject)
+        config.return_on_error.call(subject, method, error)
       else
         config.return_on_error
       end

--- a/lib/pipe/version.rb
+++ b/lib/pipe/version.rb
@@ -1,3 +1,3 @@
 module Pipe
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/lib/pipe/version.rb
+++ b/lib/pipe/version.rb
@@ -1,3 +1,3 @@
 module Pipe
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/pipe/config_spec.rb
+++ b/spec/pipe/config_spec.rb
@@ -10,6 +10,10 @@ describe Pipe::Config do
       expect(Pipe::Config.new.raise_on_error).to eq(true)
     end
 
+    it "sets return_on_error to :subject" do
+      expect(Pipe::Config.new.return_on_error).to eq(:subject)
+    end
+
     it "sets skip_on to a proc which returns false" do
       expect(Pipe::Config.new.skip_on.call).to eq(false)
     end


### PR DESCRIPTION
the default setting, :subject, will return the value of the subject when the error occurred
if the value is a proc or other callable object, the object will be called with the current value of subject, the method call being attempted when the error occurred and the error object, in that order
otherwise the value of the setting will be returned
